### PR TITLE
Fix pso.h build error

### DIFF
--- a/swarm_library/pso/include/pso/pso.h
+++ b/swarm_library/pso/include/pso/pso.h
@@ -30,6 +30,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 #include <vector>
 #include <stack>
 #include <map>
+#include <math.h>
 #include <set>
 #include <queue>
 #include <algorithm>


### PR DESCRIPTION
Add #include <math.h> to pso.h to correct a compile time error.